### PR TITLE
Fixing missing attribute accessor

### DIFF
--- a/lib/zooz/request/verify.rb
+++ b/lib/zooz/request/verify.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/module/delegation'
 module Zooz
   class Request
     class Verify
-      attr_accessor :trx_id
+      attr_accessor :trx_id, :requestor
       attr_reader :errors
       delegate :sandbox, :sandbox=, :unique_id, :unique_id=, :app_key,
         :app_key=, :response_type, :response_type=, :cmd, :cmd=, :is_sandbox?,

--- a/zooz.gemspec
+++ b/zooz.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'zooz'
-  s.version     = '1.0.2'
-  s.date        = '2012-08-23'
+  s.version     = '1.0.3'
+  s.date        = '2014-05-15'
   s.summary     = "ZooZ"
   s.description = "A ZooZ API library for Ruby"
   s.authors     = ["Michael Alexander"]


### PR DESCRIPTION
An instance of Zooz::Request::Verify was raising an error when trying to set any of its requestor attributes:

``` ruby
req = Zooz::Request::Verify.new
req.sandbox = true
# NameError: undefined local variable or method `requestor' for #<Zooz::Request::Verify:0x007fc8e1553758>
```
